### PR TITLE
EQL3 Fix

### DIFF
--- a/!Questie/Questie.lua
+++ b/!Questie/Questie.lua
@@ -418,7 +418,6 @@ function Questie:OnEvent(this, event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, 
 					end
 					QuestieTrackedQuests[hash] = nil;
 				end
-				CompleteQuest();
 				Questie:AddEvent("CHECKLOG", 0.135);
 			end
 		end


### PR DESCRIPTION
* Fixes a bug when using EQL3/ShaguQuest. Quest progression page is not skipped anymore.
* See #257