### PR TITLE
Fix missing tooltip in #270

### DIFF
--- a/!Questie/Questie.lua
+++ b/!Questie/Questie.lua
@@ -237,6 +237,7 @@ function Questie:OnLoad()
 	this:RegisterEvent("ADDON_LOADED");
 	this:RegisterEvent("VARIABLES_LOADED");
 	this:RegisterEvent("CHAT_MSG_LOOT");
+	this:RegisterEvent("UPDATE_MOUSEOVER_UNIT");
 	QuestAbandonOnAccept = StaticPopupDialogs["ABANDON_QUEST"].OnAccept;
 	StaticPopupDialogs["ABANDON_QUEST"].OnAccept = function()
 		local hash = Questie:GetHashFromName(QGet_AbandonQuestName());
@@ -454,6 +455,8 @@ function Questie:OnEvent(this, event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, 
 		if msg then
 			Questie:CheckQuestLog();
 		end
+	elseif(event == "UPDATE_MOUSEOVER_UNIT") then
+		GameTooltip.QuestieDone = nil
 	end
 end
 ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Tooltip missing when triggering mouseover a second time before tooltip fades out. Removing QuestieDone check and forcing tooltip update resolves issue. Further refactoring required to Questie:Tooltip() in Modules/QuestieNotes.lua:218 in relation to this change?