### PR TITLE
Changed "dead corpse" to "corpse". Less redundant.

### DIFF
--- a/!Questie/Questie.lua
+++ b/!Questie/Questie.lua
@@ -493,7 +493,7 @@ function Questie:OnUpdate(elapsed)
         if (QuestieConfig.corpseArrow == true) then
             if DiedAtX and DiedAtY and DiedAtX ~= 0 and DiedAtY ~= 0 then
                 local ddist, xDelta, yDelta = Astrolabe:ComputeDistance(DiedInCont, DiedInZone, DiedAtX, DiedAtY, continent, zone, xNote, yNote)
-                local dtitle = "My Dead Corpse"
+                local dtitle = "My Corpse"
                 local dpoint = {c = DiedInCont, z = DiedInZone, x = DiedAtX, y = DiedAtY}
                 SetCrazyArrow(dpoint, ddist, dtitle);
                 if (not WorldMapFrame:IsVisible() == nil) then


### PR DESCRIPTION
"My Dead Corpse" was redundant.

Thanks for making Elysium playable by the way.