### PR TITLE
Replaced primitive exact coordinate based grouping with distance based Hierarchical Clustering.

### DIFF
--- a/!Questie/Modules/QuestieNotes.lua
+++ b/!Questie/Modules/QuestieNotes.lua
@@ -938,26 +938,32 @@ function Cluster:CalculateClusters(clusters, distanceThreshold, maxClusterSize)
     end
 end
 
-function Questie:AddClusterFromNote(frame, v)
+function Questie:AddClusterFromNote(frame, identifier, v)
     if clustersByFrame == nil then
         clustersByFrame = {}
     end
     if clustersByFrame[frame] == nil then
         clustersByFrame[frame] = {}
+    end
+    if clustersByFrame[frame][identifier] == nil then
+        clustersByFrame[frame][identifier] = {}
     end
     local points = { v }
     local cluster = Cluster.new(points)
-    table.insert(clustersByFrame[frame], cluster);
+    table.insert(clustersByFrame[frame][identifier], cluster);
 end
 
-function Questie:GetClustersByFrame(frame)
+function Questie:GetClustersByFrame(frame, identifier)
     if clustersByFrame == nil then
         clustersByFrame = {}
     end
     if clustersByFrame[frame] == nil then
         clustersByFrame[frame] = {}
     end
-    return clustersByFrame[frame]
+    if clustersByFrame[frame][identifier] == nil then
+        clustersByFrame[frame][identifier] = {}
+    end
+    return clustersByFrame[frame][identifier]
 end
 ---------------------------------------------------------------------------------------------------
 -- Finds the index of an item in a table. Not sure if a function already exists somewhere.
@@ -981,27 +987,15 @@ function Questie:DRAW_NOTES()
             --If an available quest isn't in the zone or we aren't tracking a quest on the QuestTracker then hide the objectives from the minimap
             if ( (not QuestieConfig.hideMinimapIcons) or (QuestieConfig.alwaysShowQuests == false) ) and ((MMLastX ~= 0) and (MMLastY ~= 0)) and (QuestieTrackedQuests[v.questHash] ~= nil) and (QuestieTrackedQuests[v.questHash]["tracked"] ~= false) or (v.icontype == "complete") or (v.icontype == "available") then
                 if v.icontype == "complete" then
-                    Questie:AddClusterFromNote("MiniMapNote", v)
+                    Questie:AddClusterFromNote("MiniMapNote", "Quests", v)
                 else
-                    MMIcon = Questie:GetBlankNoteFrame();
-                    Questie:SetFrameNoteData(MMIcon, v, Minimap, 9, "MiniMapNote", QUESTIE_NOTES_MINIMAP_ICON_SCALE)
-                    --Sets highlight texture (Nothing stops us from doing this on the worldmap aswell)
-                    MMIcon:SetHighlightTexture(QuestieIcons[v.icontype].path, "ADD");
-                    --Set the texture to the right type
-                    Astrolabe:PlaceIconOnMinimap(MMIcon, v.continent, v.zoneid, v.x, v.y);
-                    table.insert(QuestieUsedNoteFrames, MMIcon);
+                    Questie:AddClusterFromNote("MiniMapNote", "Objectives", v)
                 end
             elseif (QuestieConfig.alwaysShowQuests == true) and not QuestieConfig.hideMinimapIcons then
                 if v.icontype == "complete" or v.icontype == "available" then
-                    Questie:AddClusterFromNote("MiniMapNote", v)
+                    Questie:AddClusterFromNote("MiniMapNote", "Quests", v)
                 else
-                    MMIcon = Questie:GetBlankNoteFrame();
-                    Questie:SetFrameNoteData(MMIcon, v, Minimap, 9, "MiniMapNote", QUESTIE_NOTES_MINIMAP_ICON_SCALE)
-                    --Sets highlight texture (Nothing stops us from doing this on the worldmap aswell)
-                    MMIcon:SetHighlightTexture(QuestieIcons[v.icontype].path, "ADD");
-                    --Set the texture to the right type
-                    Astrolabe:PlaceIconOnMinimap(MMIcon, v.continent, v.zoneid, v.x, v.y);
-                    table.insert(QuestieUsedNoteFrames, MMIcon);
+                    Questie:AddClusterFromNote("MiniMapNote", "Objectives", v)
                 end
             end
         end
@@ -1014,45 +1008,15 @@ function Questie:DRAW_NOTES()
                     --If we aren't tracking a quest on the QuestTracker then hide the objectives from the worldmap
                     if ( ( (QuestieTrackedQuests[v.questHash] ~= nil) and (QuestieTrackedQuests[v.questHash]["tracked"] ~= false) ) or (v.icontype == "complete") ) and (QuestieConfig.alwaysShowQuests == false) then
                         if v.icontype == "complete" then
-                            Questie:AddClusterFromNote("WorldMapNote", v)
+                            Questie:AddClusterFromNote("WorldMapNote", "Quests", v)
                         else
-                            Icon = Questie:GetBlankNoteFrame();
-                            local scale = QUESTIE_NOTES_MAP_ICON_SCALE;
-                            if(z == 0 and c == 0) then--Both continents
-                                scale = QUESTIE_NOTES_WORLD_MAP_ICON_SCALE;
-                            elseif(z == 0) then--Single continent
-                                scale = QUESTIE_NOTES_CONTINENT_ICON_SCALE;
-                            end
-                            Questie:SetFrameNoteData(Icon, v, WorldMapFrame, 9, "WorldMapNote", scale)
-                            --Shows and then calls Astrolabe to place it on the map.
-                            Icon:Show();
-                            xx, yy = Astrolabe:PlaceIconOnWorldMap(WorldMapButton,Icon,v.continent ,v.zoneid ,v.x, v.y); --WorldMapFrame is global
-                            if(xx and yy and xx > 0 and xx < 1 and yy > 0 and yy < 1) then
-                                table.insert(QuestieUsedNoteFrames, Icon);
-                            else
-                                Questie:Clear_Note(Icon);
-                            end
+                            Questie:AddClusterFromNote("WorldMapNote", "Objectives", v)
                         end
                     elseif (QuestieConfig.alwaysShowQuests == true) then
                         if v.icontype == "complete" then
-                            Questie:AddClusterFromNote("WorldMapNote", v)
+                            Questie:AddClusterFromNote("WorldMapNote", "Quests", v)
                         else
-                            Icon = Questie:GetBlankNoteFrame();
-                            local scale = QUESTIE_NOTES_MAP_ICON_SCALE;
-                            if(z == 0 and c == 0) then--Both continents
-                                scale = QUESTIE_NOTES_WORLD_MAP_ICON_SCALE;
-                            elseif(z == 0) then--Single continent
-                                scale = QUESTIE_NOTES_CONTINENT_ICON_SCALE;
-                            end
-                            Questie:SetFrameNoteData(Icon, v, WorldMapFrame, 9, "WorldMapNote", scale)
-                            --Shows and then calls Astrolabe to place it on the map.
-                            Icon:Show();
-                            xx, yy = Astrolabe:PlaceIconOnWorldMap(WorldMapButton,Icon,v.continent ,v.zoneid ,v.x, v.y); --WorldMapFrame is global
-                            if(xx and yy and xx > 0 and xx < 1 and yy > 0 and yy < 1) then
-                                table.insert(QuestieUsedNoteFrames, Icon);
-                            else
-                                Questie:Clear_Note(Icon);
-                            end
+                            Questie:AddClusterFromNote("WorldMapNote", "Objectives", v)
                         end
                     end
                 end
@@ -1065,30 +1029,51 @@ function Questie:DRAW_NOTES()
         if Active == true then
             local con,zon,x,y = Astrolabe:GetCurrentPlayerPosition();
             for k, v in pairs(QuestieAvailableMapNotes[c][z]) do
-                Questie:AddClusterFromNote("WorldMapNote", v)
-                Questie:AddClusterFromNote("MiniMapNote", v)
+                Questie:AddClusterFromNote("WorldMapNote", "Quests", v)
+                Questie:AddClusterFromNote("MiniMapNote", "Quests", v)
             end
         end
     end
 
-    local worldMapClusters = Questie:GetClustersByFrame("WorldMapNote")
-    Cluster:CalculateClusters(worldMapClusters, 0.025, 5)
-    local minimapClusters = Questie:GetClustersByFrame("WorldMapNote")
-    Cluster:CalculateClusters(minimapClusters, 0, 5) -- maxClusterSize is irrelevant if distanceThreshold is set to 0, because items with a distance of 0 are always clustered.
+    -- maxClusterSize is irrelevant if distanceThreshold is set to 0, because items with a distance of 0 are always clustered.
+    local minimapObjectiveClusters = Questie:GetClustersByFrame("MiniMapNote", "Objectives")
+    Cluster:CalculateClusters(minimapObjectiveClusters, 0, 5)
+    local worldMapObjectiveClusters = Questie:GetClustersByFrame("WorldMapNote", "Objectives")
+    Cluster:CalculateClusters(worldMapObjectiveClusters, 0, 5)
 
-    Questie:DrawClusters("WorldMapNote", WorldMapFrame, WorldMapButton)
-    Questie:DrawClusters("MiniMapNote", Minimap)
+    local worldMapClusters = Questie:GetClustersByFrame("WorldMapNote", "Quests")
+    Cluster:CalculateClusters(worldMapClusters, 0.025, 5)
+    local minimapClusters = Questie:GetClustersByFrame("MiniMapNote", "Quests")
+    Cluster:CalculateClusters(minimapClusters, 0, 5)
+
+
+    local scale = QUESTIE_NOTES_MAP_ICON_SCALE;
+    if(z == 0 and c == 0) then--Both continents
+        scale = QUESTIE_NOTES_WORLD_MAP_ICON_SCALE;
+    elseif(z == 0) then--Single continent
+        scale = QUESTIE_NOTES_CONTINENT_ICON_SCALE;
+    end
+    Questie:DrawClusters("WorldMapNote", "Objectives", scale, WorldMapFrame, WorldMapButton)
+    Questie:DrawClusters("WorldMapNote", "Quests", scale, WorldMapFrame, WorldMapButton)
+    Questie:DrawClusters("MiniMapNote", "Objectives", QUESTIE_NOTES_MINIMAP_ICON_SCALE, Minimap)
+    Questie:DrawClusters("MiniMapNote", "Quests", QUESTIE_NOTES_MINIMAP_ICON_SCALE, Minimap)
 end
 
-function Questie:DrawClusters(frameName, frame, button)
+function Questie:DrawClusters(frameName, identifier, scale, frame, button)
     local frameLevel = 9
-    local scale = QUESTIE_NOTES_MAP_ICON_SCALE
     if frameName == "MiniMapNote" then
         frameLevel = 7
-        scale = QUESTIE_NOTES_MINIMAP_ICON_SCALE
     end
-    local clusters = Questie:GetClustersByFrame(frameName)
+    local clusters = Questie:GetClustersByFrame(frameName, identifier)
     for i, cluster in pairs(clusters) do
+        table.sort(cluster.points, function(a, b)
+            local questA = QuestieHashMap[a.questHash]
+            local questB = QuestieHashMap[b.questHash]
+            return
+                (a.icontype == "complete" and b.icontype ~= "complete") or
+                (a.icontype == b.icontype and questA.level < questB.level) or
+                (questA.level == questB.level and questA.questLevel < questB.questLevel)
+        end)
         Icon = Questie:GetBlankNoteFrame()
         local mainV = cluster.points[1]
         for j, v in pairs(cluster.points) do
@@ -1100,6 +1085,7 @@ function Questie:DrawClusters(frameName, frame, button)
         end
         Icon:Show()
         if frameName == "MiniMapNote" then
+            Icon:SetHighlightTexture(QuestieIcons[mainV.icontype].path, "ADD");
             Astrolabe:PlaceIconOnMinimap(Icon, mainV.continent, mainV.zoneid, Icon.averageX, Icon.averageY);
         else
             xx, yy = Astrolabe:PlaceIconOnWorldMap(button, Icon, mainV.continent, mainV.zoneid, Icon.averageX, Icon.averageY)

--- a/!Questie/Modules/QuestieNotes.lua
+++ b/!Questie/Modules/QuestieNotes.lua
@@ -1072,7 +1072,7 @@ function Questie:DrawClusters(frameName, identifier, scale, frame, button)
             return
                 (a.icontype == "complete" and b.icontype ~= "complete") or
                 (a.icontype == b.icontype and questA.level < questB.level) or
-                (questA.level == questB.level and questA.questLevel < questB.questLevel)
+                (a.icontype == b.icontype and questA.level == questB.level and questA.questLevel < questB.questLevel)
         end)
         Icon = Questie:GetBlankNoteFrame()
         local mainV = cluster.points[1]

--- a/!Questie/Modules/QuestieNotes.lua
+++ b/!Questie/Modules/QuestieNotes.lua
@@ -1061,7 +1061,9 @@ function Questie:DRAW_NOTES()
 
     local minimapClusters = Questie:GetClustersByFrame("MiniMapNote", "Quests")
     local worldMapClusters = Questie:GetClustersByFrame("WorldMapNote", "Quests")
-    Cluster:CalculateClusters(worldMapClusters, 0.025, 5)
+    if QuestieConfig.clusterQuests then
+        Cluster:CalculateClusters(worldMapClusters, 0.025, 5)
+    end
 
 
     local scale = QUESTIE_NOTES_MAP_ICON_SCALE;

--- a/!Questie/Modules/QuestieNotes.lua
+++ b/!Questie/Modules/QuestieNotes.lua
@@ -914,13 +914,15 @@ function Cluster:CalculateClusters(clusters, distanceThreshold, maxClusterSize)
             for j, otherCluster in pairs(clusters) do
                 if cluster ~= otherCluster then
                     local distance = Cluster.CalculateLinkageDistance(cluster.points, otherCluster.points)
-                    if ((nearestDistance == nil) or (distance < nearestDistance)) and (table.getn(cluster.points) + table.getn(otherCluster.points) <= maxClusterSize or distance == 0) then
+                    if distance == 0 or ((nearestDistance == nil or distance < nearestDistance) and (table.getn(cluster.points) + table.getn(otherCluster.points) <= maxClusterSize)) then
                         nearestDistance = distance
                         nearest1 = cluster
                         nearest2 = otherCluster
                     end
                 end
+                if nearestDistance == 0 then break end
             end
+            if nearestDistance == 0 then break end
         end
 
         if nearestDistance == nil or nearestDistance > distanceThreshold then break end

--- a/!Questie/Modules/QuestieNotes.lua
+++ b/!Questie/Modules/QuestieNotes.lua
@@ -747,7 +747,6 @@ function Questie:AddFrameNoteData(icon, data)
         icon.averageX = newAverageX
         icon.averageY = newAverageY
         table.insert(icon.quests, data)
-        Astrolabe:PlaceIconOnWorldMap(WorldMapButton,icon,data.continent ,data.zoneid ,icon.averageX, icon.averageY)
     end
 end
 

--- a/!Questie/Modules/QuestieNotes.lua
+++ b/!Questie/Modules/QuestieNotes.lua
@@ -870,9 +870,7 @@ function Questie:CLEAR_ALL_NOTES()
     --DEFAULT_CHAT_FRAME:AddMessage("Clearing map notes!")
     Questie:debug_Print("CLEAR_NOTES");
     Astrolabe:RemoveAllMinimapIcons();
-    questsByFrameAndPosition = {};
-    questsByFrameAndPosition["WorldMapNote"] = {};
-    questsByFrameAndPosition["MiniMapNote"] = {};
+    clustersByFrame = nil
     for k, v in pairs(QuestieUsedNoteFrames) do
         --Questie:debug_Print("Hash:"..v.questHash,"Type:"..v.type);
         Questie:Clear_Note(v);
@@ -880,42 +878,63 @@ function Questie:CLEAR_ALL_NOTES()
     QuestieUsedNoteFrames = {};
 end
 ---------------------------------------------------------------------------------------------------
--- Rounds numbers. don't know where to put this function
+-- Logic for clusters
 ---------------------------------------------------------------------------------------------------
-function round(x)
-    return tonumber(string.format("%.1f", x))
-end
----------------------------------------------------------------------------------------------------
--- Gets/Sets grouped quests
----------------------------------------------------------------------------------------------------
-function Questie:GetGroupedQuests(frame, v)
-    local roundedX = v.x
-    local roundedY = v.y
-    if (v.icontype == "complete" or v.icontype == "available") then
-	    roundedX = round(v.x)
-	    roundedY = round(v.y)
-	end
-    if (questsByFrameAndPosition[frame][v.continent] == nil) then
-        questsByFrameAndPosition[frame][v.continent] = {}
-    end
-    if (questsByFrameAndPosition[frame][v.continent][v.zoneid] == nil) then
-        questsByFrameAndPosition[frame][v.continent][v.zoneid] = {}
-    end
-	if (questsByFrameAndPosition[frame][v.continent][v.zoneid][roundedX] == nil) then
-		questsByFrameAndPosition[frame][v.continent][v.zoneid][roundedX] = {}
-	end
-	local existingQuest = questsByFrameAndPosition[frame][v.continent][v.zoneid][roundedX][roundedY]
-	return existingQuest
+local Cluster = {}
+Cluster.__index = Cluster
+
+function Cluster.new(points)
+    local self = setmetatable({}, Cluster)
+    self.points = points
+    return self
 end
 
-function Questie:SetGroupedQuests(frame, v, icon)
-    local roundedX = v.x
-    local roundedY = v.y
-    if (v.icontype == "complete" or v.icontype == "available") then
-	    roundedX = round(v.x)
-	    roundedY = round(v.y)
-	end
-	questsByFrameAndPosition[frame][v.continent][v.zoneid][roundedX][roundedY] = icon
+function Cluster.CalculateDistance(x1, y1, x2, y2)
+    local deltaX = x1 - x2
+    local deltaY = y1 - y2
+    return sqrt(deltaX*deltaX + deltaY*deltaY)
+end
+
+function Cluster.CalculateLinkageDistance(cluster1, cluster2)
+    local total = 0
+    for i, pi in cluster1 do
+        for j, pj in cluster2 do
+            local distance = Cluster.CalculateDistance(pi.x, pi.y, pj.x, pj.y)
+            total = total + distance;
+        end
+    end
+    return total / (table.getn(cluster1) * table.getn(cluster2))
+end
+
+function Questie:AddClusterFromNote(frame, v)
+    if clustersByFrame == nil then
+        clustersByFrame = {}
+    end
+    if clustersByFrame[frame] == nil then
+        clustersByFrame[frame] = {}
+    end
+    local points = { v }
+    local cluster = Cluster.new(points)
+    table.insert(clustersByFrame[frame], cluster);
+end
+
+function Questie:GetClustersByFrame(frame)
+    if clustersByFrame == nil then
+        clustersByFrame = {}
+    end
+    if clustersByFrame[frame] == nil then
+        clustersByFrame[frame] = {}
+    end
+    return clustersByFrame[frame]
+end
+---------------------------------------------------------------------------------------------------
+-- Finds the index of an item in a table. Not sure if a function already exists somewhere.
+---------------------------------------------------------------------------------------------------
+function indexOf(table, item)
+    for k, v in pairs(table) do
+        if v == item then return k end
+    end
+    return nil
 end
 ---------------------------------------------------------------------------------------------------
 -- Checks first if there are any notes for the current zone, then draws the desired icon
@@ -924,20 +943,14 @@ function Questie:DRAW_NOTES()
     --DEFAULT_CHAT_FRAME:AddMessage("Drawing map notes!")
     local c, z = GetCurrentMapContinent(), GetCurrentMapZone();
     Questie:debug_Print("DRAW_NOTES");
+    -- Draw minimap objective markers
     if(QuestieMapNotes[c] and QuestieMapNotes[c][z]) then
         for k, v in pairs(QuestieMapNotes[c][z]) do
             --If an available quest isn't in the zone or we aren't tracking a quest on the QuestTracker then hide the objectives from the minimap
             if ( (not QuestieConfig.hideMinimapIcons) or (QuestieConfig.alwaysShowQuests == false) ) and ((MMLastX ~= 0) and (MMLastY ~= 0)) and (QuestieTrackedQuests[v.questHash] ~= nil) and (QuestieTrackedQuests[v.questHash]["tracked"] ~= false) or (v.icontype == "complete") or (v.icontype == "available") then
-                MMIcon = Questie:GetBlankNoteFrame();
-                Questie:SetFrameNoteData(MMIcon, v, Minimap, 9, "MiniMapNote", QUESTIE_NOTES_MINIMAP_ICON_SCALE)
-                --Sets highlight texture (Nothing stops us from doing this on the worldmap aswell)
-                MMIcon:SetHighlightTexture(QuestieIcons[v.icontype].path, "ADD");
-                --Set the texture to the right type
-                Astrolabe:PlaceIconOnMinimap(MMIcon, v.continent, v.zoneid, v.x, v.y);
-                table.insert(QuestieUsedNoteFrames, MMIcon);
-            elseif (QuestieConfig.alwaysShowQuests == true) then
-                local existingQuest = Questie:GetGroupedQuests("MiniMapNote", v)
-                if (existingQuest == nil) and not QuestieConfig.hideMinimapIcons then
+                if v.icontype == "complete" then
+                    Questie:AddClusterFromNote("MiniMapNote", v)
+                else
                     MMIcon = Questie:GetBlankNoteFrame();
                     Questie:SetFrameNoteData(MMIcon, v, Minimap, 9, "MiniMapNote", QUESTIE_NOTES_MINIMAP_ICON_SCALE)
                     --Sets highlight texture (Nothing stops us from doing this on the worldmap aswell)
@@ -945,33 +958,40 @@ function Questie:DRAW_NOTES()
                     --Set the texture to the right type
                     Astrolabe:PlaceIconOnMinimap(MMIcon, v.continent, v.zoneid, v.x, v.y);
                     table.insert(QuestieUsedNoteFrames, MMIcon);
-                    Questie:SetGroupedQuests("MiniMapNote", v, MMIcon)
+                end
+            elseif (QuestieConfig.alwaysShowQuests == true) and not QuestieConfig.hideMinimapIcons then
+                if v.icontype == "complete" or v.icontype == "available" then
+                    Questie:AddClusterFromNote("MiniMapNote", v)
                 else
-                    Questie:AddFrameNoteData(existingQuest, v)
+                    MMIcon = Questie:GetBlankNoteFrame();
+                    Questie:SetFrameNoteData(MMIcon, v, Minimap, 9, "MiniMapNote", QUESTIE_NOTES_MINIMAP_ICON_SCALE)
+                    --Sets highlight texture (Nothing stops us from doing this on the worldmap aswell)
+                    MMIcon:SetHighlightTexture(QuestieIcons[v.icontype].path, "ADD");
+                    --Set the texture to the right type
+                    Astrolabe:PlaceIconOnMinimap(MMIcon, v.continent, v.zoneid, v.x, v.y);
+                    table.insert(QuestieUsedNoteFrames, MMIcon);
                 end
             end
         end
     end
+    -- Draw world map objective markers
     for k, Continent in pairs(QuestieMapNotes) do
         for zone, noteHeap in pairs(Continent) do
             for k, v in pairs(noteHeap) do
                 if true then
                     --If we aren't tracking a quest on the QuestTracker then hide the objectives from the worldmap
                     if ( ( (QuestieTrackedQuests[v.questHash] ~= nil) and (QuestieTrackedQuests[v.questHash]["tracked"] ~= false) ) or (v.icontype == "complete") ) and (QuestieConfig.alwaysShowQuests == false) then
-                        local existingQuest = Questie:GetGroupedQuests("WorldMapNote", v)
-                        if (existingQuest == nil) then
+                        if v.icontype == "complete" then
+                            Questie:AddClusterFromNote("WorldMapNote", v)
+                        else
                             Icon = Questie:GetBlankNoteFrame();
-                            local frameLevel = 9;
-                            if (v.icontype == "complete") then
-                                frameLevel = 10;
-                            end
                             local scale = QUESTIE_NOTES_MAP_ICON_SCALE;
                             if(z == 0 and c == 0) then--Both continents
                                 scale = QUESTIE_NOTES_WORLD_MAP_ICON_SCALE;
                             elseif(z == 0) then--Single continent
                                 scale = QUESTIE_NOTES_CONTINENT_ICON_SCALE;
                             end
-                            Questie:SetFrameNoteData(Icon, v, WorldMapFrame, frameLevel, "WorldMapNote", scale)
+                            Questie:SetFrameNoteData(Icon, v, WorldMapFrame, 9, "WorldMapNote", scale)
                             --Shows and then calls Astrolabe to place it on the map.
                             Icon:Show();
                             xx, yy = Astrolabe:PlaceIconOnWorldMap(WorldMapButton,Icon,v.continent ,v.zoneid ,v.x, v.y); --WorldMapFrame is global
@@ -980,25 +1000,19 @@ function Questie:DRAW_NOTES()
                             else
                                 Questie:Clear_Note(Icon);
                             end
-                            Questie:SetGroupedQuests("WorldMapNote", v, Icon)
-                        else
-                            Questie:AddFrameNoteData(existingQuest, v)
                         end
                     elseif (QuestieConfig.alwaysShowQuests == true) then
-                        local existingQuest = Questie:GetGroupedQuests("WorldMapNote", v)
-                        if (existingQuest == nil) then
+                        if v.icontype == "complete" then
+                            Questie:AddClusterFromNote("WorldMapNote", v)
+                        else
                             Icon = Questie:GetBlankNoteFrame();
-                            local frameLevel = 9;
-                            if (v.icontype == "complete") then
-                                frameLevel = 10;
-                            end
                             local scale = QUESTIE_NOTES_MAP_ICON_SCALE;
                             if(z == 0 and c == 0) then--Both continents
                                 scale = QUESTIE_NOTES_WORLD_MAP_ICON_SCALE;
                             elseif(z == 0) then--Single continent
                                 scale = QUESTIE_NOTES_CONTINENT_ICON_SCALE;
                             end
-                            Questie:SetFrameNoteData(Icon, v, WorldMapFrame, frameLevel, "WorldMapNote", scale)
+                            Questie:SetFrameNoteData(Icon, v, WorldMapFrame, 9, "WorldMapNote", scale)
                             --Shows and then calls Astrolabe to place it on the map.
                             Icon:Show();
                             xx, yy = Astrolabe:PlaceIconOnWorldMap(WorldMapButton,Icon,v.continent ,v.zoneid ,v.x, v.y); --WorldMapFrame is global
@@ -1007,47 +1021,91 @@ function Questie:DRAW_NOTES()
                             else
                                 Questie:Clear_Note(Icon);
                             end
-                            Questie:SetGroupedQuests("WorldMapNote", v, Icon)
-                        else
-                            Questie:AddFrameNoteData(existingQuest, v)
                         end
                     end
                 end
             end
         end
     end
+
+    -- Draw available quest markers.
     if(QuestieAvailableMapNotes[c] and QuestieAvailableMapNotes[c][z]) then
         if Active == true then
             local con,zon,x,y = Astrolabe:GetCurrentPlayerPosition();
             for k, v in pairs(QuestieAvailableMapNotes[c][z]) do
-                local existingQuest = Questie:GetGroupedQuests("WorldMapNote", v)
-                if (existingQuest == nil) then
-                    Icon = Questie:GetBlankNoteFrame();
-                    Questie:SetFrameNoteData(Icon, v, WorldMapFrame, 9, "WorldMapNote", QUESTIE_NOTES_MAP_ICON_SCALE)
-                    Icon:Show();
-                    xx, yy = Astrolabe:PlaceIconOnWorldMap(WorldMapButton,Icon,v.continent ,v.zoneid ,v.x, v.y); --WorldMapFrame is global
-                    if(xx and yy and xx > 0 and xx < 1 and yy > 0 and yy < 1) then
-                        table.insert(QuestieUsedNoteFrames, Icon);
-                    else
-                        Questie:Clear_Note(Icon);
+                Questie:AddClusterFromNote("WorldMapNote", v)
+                Questie:AddClusterFromNote("MiniMapNote", v)
+            end
+        end
+    end
+
+    Questie:CalculateClusters("WorldMapNote", 0.025, 5)
+    Questie:CalculateClusters("MiniMapNote", 0, 5) -- maxClusterSize is irrelevant if distanceThreshold is set to 0, because items with a distance of 0 are always clustered.
+
+    Questie:DrawClusters("WorldMapNote", WorldMapFrame, WorldMapButton)
+    Questie:DrawClusters("MiniMapNote", Minimap)
+end
+
+function Questie:CalculateClusters(frame, distanceThreshold, maxClusterSize)
+    local clusters = Questie:GetClustersByFrame(frame)
+    while table.getn(clusters) > 1 do
+        local nearest1
+        local nearest2
+        local nearestDistance
+        for i, cluster in pairs(clusters) do
+            for j, otherCluster in pairs(clusters) do
+                if cluster ~= otherCluster then
+                    local distance = Cluster.CalculateLinkageDistance(cluster.points, otherCluster.points)
+                    if ((nearestDistance == nil) or (distance < nearestDistance)) and (table.getn(cluster.points) + table.getn(otherCluster.points) <= maxClusterSize or distance == 0) then
+                        nearestDistance = distance
+                        nearest1 = cluster
+                        nearest2 = otherCluster
                     end
-                    Questie:SetGroupedQuests("WorldMapNote", v, Icon)
-                else
-                    Questie:AddFrameNoteData(existingQuest, v)
                 end
-                existingQuest = Questie:GetGroupedQuests("MiniMapNote", v)
-                if (existingQuest == nil) and not QuestieConfig.hideMinimapIcons then
-                    MMIcon = Questie:GetBlankNoteFrame();
-                    Questie:SetFrameNoteData(MMIcon, v, Minimap, 7, "MiniMapNote", QUESTIE_NOTES_MINIMAP_ICON_SCALE)
-                    --Sets highlight texture (Nothing stops us from doing this on the worldmap aswell)
-                    MMIcon:SetHighlightTexture(QuestieIcons[v.icontype].path, "ADD");
-                    --Set the texture to the right type
-                    Astrolabe:PlaceIconOnMinimap(MMIcon, v.continent, v.zoneid, v.x, v.y);
-                    table.insert(QuestieUsedNoteFrames, MMIcon);
-                    Questie:SetGroupedQuests("MiniMapNote", v, MMIcon)
-                else
-                    Questie:AddFrameNoteData(existingQuest, v)
-                end
+            end
+        end
+
+        if nearestDistance == nil or nearestDistance > distanceThreshold then break end
+        local index1 = indexOf(clusters, nearest1)
+        table.remove(clusters, index1)
+        local index2 = indexOf(clusters, nearest2)
+        table.remove(clusters, index2)
+
+        local points = nearest1.points
+        for i, point in pairs(nearest2.points) do
+            table.insert(points, point)
+        end
+        local newCluster = Cluster.new(points)
+        table.insert(clusters, newCluster)
+    end
+end
+
+function Questie:DrawClusters(frameName, frame, button)
+    local frameLevel = 9
+    local scale = QUESTIE_NOTES_MAP_ICON_SCALE
+    if frameName == "MiniMapNote" then
+        frameLevel = 7
+        scale = QUESTIE_NOTES_MINIMAP_ICON_SCALE
+    end
+    for i, cluster in pairs(clustersByFrame[frameName]) do
+        Icon = Questie:GetBlankNoteFrame()
+        local mainV = cluster.points[1]
+        for j, v in pairs(cluster.points) do
+            if j == 1 then
+                Questie:SetFrameNoteData(Icon, v, frame, frameLevel, frameName, scale)
+            else
+                Questie:AddFrameNoteData(Icon, v)
+            end
+        end
+        Icon:Show()
+        if frameName == "MiniMapNote" then
+            Astrolabe:PlaceIconOnMinimap(Icon, mainV.continent, mainV.zoneid, Icon.averageX, Icon.averageY);
+        else
+            xx, yy = Astrolabe:PlaceIconOnWorldMap(button, Icon, mainV.continent, mainV.zoneid, Icon.averageX, Icon.averageY)
+            if(xx and yy and xx > 0 and xx < 1 and yy > 0 and yy < 1) then
+                table.insert(QuestieUsedNoteFrames, Icon);
+            else
+                Questie:Clear_Note(Icon);
             end
         end
     end

--- a/!Questie/Modules/QuestieNotes.lua
+++ b/!Questie/Modules/QuestieNotes.lua
@@ -732,11 +732,11 @@ function Questie:AddFrameNoteData(icon, data)
             icon.averageX = 0
             icon.averageY = 0
         end
-		local numQuests = table.getn(icon.quests)
-		local newAverageX = (icon.averageX * numQuests + data.x) / (numQuests + 1)
-		local newAverageY = (icon.averageY * numQuests + data.y) / (numQuests + 1)
-		icon.averageX = newAverageX
-		icon.averageY = newAverageY
+        local numQuests = table.getn(icon.quests)
+        local newAverageX = (icon.averageX * numQuests + data.x) / (numQuests + 1)
+        local newAverageY = (icon.averageY * numQuests + data.y) / (numQuests + 1)
+        icon.averageX = newAverageX
+        icon.averageY = newAverageY
         table.insert(icon.quests, data)
         Astrolabe:PlaceIconOnWorldMap(WorldMapButton,icon,data.continent ,data.zoneid ,icon.averageX, icon.averageY)
     end

--- a/!Questie/Questie.lua
+++ b/!Questie/Questie.lua
@@ -63,6 +63,7 @@ function Questie:SetupDefaults()
         ["hideMinimapIcons"] = false,
         ["hideObjectives"] = false,
         ["getVersion"] = QuestieVersion,
+        ["clusterQuests"] = true,
     }
     end
     if not QuestieTrackerVariables then QuestieTrackerVariables = {
@@ -145,6 +146,9 @@ function Questie:CheckDefaults()
     end
     if QuestieConfig.hideObjectives == nil then
         QuestieConfig.hideObjectives = false;
+    end
+    if QuestieConfig.clusterQuests == nil then
+        QuestieConfig.clusterQuests = true;
     end
     -- Setups default QuestDB's for fresh characters
     if QuestieTrackedQuests == nil then
@@ -239,6 +243,7 @@ function Questie:ClearConfig(arg)
                 ["resizeWorldmap"] = false,
                 ["hideMinimapIcons"] = false,
                 ["hideObjectives"] = false,
+                ["clusterQuests"] = true,
                 ["getVersion"] = QuestieVersion,
             }
             -- Clears tracker settings
@@ -323,6 +328,7 @@ function Questie:NUKE(arg)
                 ["resizeWorldmap"] = false,
                 ["hideMinimapIcons"] = false,
                 ["hideObjectives"] = false,
+                ["clusterQuests"] = true,
                 ["getVersion"] = QuestieVersion,
             }
             -- Clears tracker settings
@@ -1028,6 +1034,16 @@ QuestieFastSlash = {
         Questie:Toggle();
         Questie:Toggle();
     end,
+    ["cluster"] = function()
+        QuestieConfig.clusterQuests = not QuestieConfig.clusterQuests;
+        if QuestieConfig.clusterQuests then
+            DEFAULT_CHAT_FRAME:AddMessage("  Questie: Quest icons will now be clustered!");
+        else
+            DEFAULT_CHAT_FRAME:AddMessage("  Questie: Quest icons will now be separate!");
+        end
+        Questie:Toggle();
+        Questie:Toggle();
+    end,
     ["help"] = function()
         DEFAULT_CHAT_FRAME:AddMessage("Questie SlashCommand Help Menu:", 1, 0.75, 0);
         DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie arrow |r-- |c0000ffc0(toggle)|r QuestArrow", 0.75, 0.75, 0.75);
@@ -1036,6 +1052,7 @@ QuestieFastSlash = {
         DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie corpsearrow |r-- |c0000ffc0(toggle)|r CorpseArrow", 0.75, 0.75, 0.75);
         DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie clearconfig |r-- Resets Questie settings. It does NOT delete your quest data.", 0.75, 0.75, 0.75);
         DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie cleartracker |r-- Relocates the QuestTracker to the center of your screen.", 0.75, 0.75, 0.75);
+        DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie cluster |r-- |c0000ffc0(toggle)|r Cluster nearby quests together.", 0.75, 0.75, 0.75);
         DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie color |r-- Select from two different color schemes", 0.75, 0.75, 0.75);
         DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie header |r-- |c0000ffc0(toggle)|r QuestTracker log counter", 0.75, 0.75, 0.75);
         DEFAULT_CHAT_FRAME:AddMessage("|c0000c0ff  /questie hideminimap |r-- |c0000ffc0(toggle)|r Hides quest starter icons on mini map only", 0.75, 0.75, 0.75);


### PR DESCRIPTION
Quests used to be grouped together if they have exactly the same coordinate. Now they are clustered by distance to each other using a Hierarchical Clustering algorithm. The clustering distance for the world map is set to 0.025 (or 2.5 in terms of coordinates that are shown to players), while the distance for the minimap is set to 0 so that the position of the quest is as accurate on the minimap is possible. The algorithm also limits the cluster size to 5 so that too many quests don't get grouped together and become overwhelming to the tooltip that displays their info, with the exception of quests that are at a distance of 0 from each other which always get clustered together. These values can easily be tweaked in the code, which should make it possible to easily make them user-configurable.