### PR TITLE
Use a more convenient way to detect pfUI minimap

### DIFF
--- a/!Questie/astrolabe/Astrolabe.lua
+++ b/!Questie/astrolabe/Astrolabe.lua
@@ -325,7 +325,7 @@ local function placeIconOnMinimap( minimap, minimapZoom, mapWidth, mapHeight, ic
     local signx,signy =1,1;
     -- Adding square map support by LaYt
     if (Squeenix or (simpleMinimap_Skins and simpleMinimap_Skins:GetShape() == "square")
-		or (pfUI and pfUI_config["disabled"]["minimap"] ~= "1")) then
+		or (pfUI and pfUI.minimap)) then
         if (xDist<0) then signx=-1; end
         if (yDist<0) then signy=-1; end
         if (math.abs(xDist) > (mapWidth/2*xScale)) then


### PR DESCRIPTION
The old function will result in nil errors for every addon that includes the pfUI API but isn't pfUI itself. This PR will use the pfUI.minimap field which is only existing if pfUI is active and has enabled minimap support.