### PR TITLE
Fix required quests for quest 794

### DIFF
--- a/!Questie/Database/addendum.lua
+++ b/!Questie/Database/addendum.lua
@@ -28323,7 +28323,8 @@ QuestieHashMap = {
   ['finishedBy']="Zureetha Fargaze",
   ['level']=2,
   ['questLevel']='5',
-  ['rr']=178
+  ['rr']=178,
+  ['rq']=3118500082
  },
  [4210602997]={
   ['name']="To Ironforge for Yagyin's Digest",


### PR DESCRIPTION
* Quest 794 (Burning Blade Medallion) is only available after Quest 792 (Vile Familiars)