### PR TITLE
Improve note position outside square minimap

### DIFF
--- a/!Questie/astrolabe/Astrolabe.lua
+++ b/!Questie/astrolabe/Astrolabe.lua
@@ -328,11 +328,16 @@ local function placeIconOnMinimap( minimap, minimapZoom, mapWidth, mapHeight, ic
 		or (pfUI and pfUI.minimap)) then
         if (xDist<0) then signx=-1; end
         if (yDist<0) then signy=-1; end
-        if (math.abs(xDist) > (mapWidth/2*xScale)) then
-            xDist = (mapWidth/2*xScale - iconDiameter/2)*signx;
-        end
-        if (math.abs(yDist) > (mapHeight/2*yScale)) then
-            yDist = (mapHeight/2*yScale - iconDiameter/2)*signy;
+        if (math.abs(xDist) > (mapWidth/2*xScale) or math.abs(yDist) > (mapHeight/2*yScale)) then
+            local xRatio,yRatio = 1,1;
+            if ( yDist ~= 0 ) then
+              xRatio = math.min( math.abs(xDist) / math.abs(yDist), 1 );
+            end
+            if ( xDist ~= 0 ) then
+              yRatio = math.min( math.abs(yDist) / math.abs(xDist) , 1 );
+            end
+            xDist = (mapWidth/2*xScale - iconDiameter/2)*signx*xRatio;
+            yDist = (mapHeight/2*yScale - iconDiameter/2)*signy*yRatio;
         end
     elseif ( (dist + iconDiameter) > mapRadius ) then
         -- position along the outside of the Minimap


### PR DESCRIPTION
Makes the note position on square minimap border dependent on relative xy distance.

This means that orienting yourself toward the marker on the minimap should orient you toward the objective, which is not the case currently.


![questie_squareminimap_tracking](https://user-images.githubusercontent.com/16194079/39089887-60e21690-45c8-11e8-8782-5f030f226911.png)
