### PR TITLE
Questie classic

### DIFF
--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -4,6 +4,8 @@ local activeGUIDs = {};
 local npFrames = {};
 local npFramesCount = 0;
 
+QuestieNameplate.TimerSet = 2;
+
 -- Frame Management
 -- This was created mostly because the current frame pool doesn't support anything 
 -- other than world map frames and didn't want to refactor that right now
@@ -38,6 +40,7 @@ end
 
 function QuestieNameplate:removeFrame(guid)
     if npFrames[guid] then
+        npFrames[guid]:Hide();
         npFrames[guid] = nil;
     end
 
@@ -66,9 +69,10 @@ function QuestieNameplate:NameplateCreated(token)
                 Timer hack to account for delay in populating QuestieTooltips
                 Without delay, if nameplates start off toggled, then they need to
                 be toggled off and back on again or delay 2 seconds apperas instant
-                on the client.
+                on the client.  Only needs to be run once, controlled with Timer set.
             ]]
-            C_Timer.After(2, function()
+            C_Timer.After(QuestieNameplate.TimerSet, function()
+                QuestieNameplate.TimerSet = 0;
                 local toKill = QuestieTooltips.tooltipLookup["u_" .. unitName];
 
                 if toKill then

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -1,0 +1,94 @@
+QuestieNameplate = {};
+
+local activeGUIDs = {};
+local npFrames = {};
+local npFramesCount = 0;
+
+-- Frame Management
+-- This was created mostly because the current frame pool doesn't support anything 
+-- other than world map frames and didn't want to refactor that right now
+function QuestieNameplate:getFrame(guid)
+
+    if npFrames[guid] and npFrames[guid] ~= nil then
+        return npFrames[guid];
+    end
+
+    local parent = C_NamePlate.GetNamePlateForUnit(guid);
+
+    local frame = CreateFrame("Frame");
+    frame:SetFrameStrata("HIGH");
+    frame:SetFrameLevel(10);
+    frame:SetWidth(16)
+	frame:SetHeight(16)
+    frame:EnableMouse(false);
+    frame:SetParent(parent);
+    frame:SetPoint("LEFT", parent, -12, -7);
+
+    frame.Icon = frame:CreateTexture(nil, "ARTWORK");
+    frame.Icon:ClearAllPoints();
+    frame.Icon:SetTexture(ICON_TYPE_AVAILABLE);
+    frame.Icon:SetAllPoints(frame)
+
+
+    npFrames[guid] = frame;
+    npFramesCount = npFramesCount + 1;
+
+    return frame;
+end
+
+function QuestieNameplate:removeFrame(guid)
+    if npFrames[guid] then
+        npFrames[guid] = nil;
+    end
+
+    npFramesCount = npFramesCount - 1;
+end
+
+
+-- Event Handlers
+function QuestieNameplate:NameplateCreated(token)
+    -- to avoid memory issues
+    if npFramesCount >= 300 then
+        return
+    end
+
+    local unitGUID = UnitGUID(token);
+    local unitName, _ = UnitName(token);
+
+    -- we only need to use put this over creatures.
+    -- to avoid running this code over Pet, Player, etc.
+    local unitType = strsplit("-", unitGUID);
+
+    if unitType == "Creature" then
+
+        if unitName then
+            --[[
+                Timer hack to account for delay in populating QuestieTooltips
+                Without delay, if nameplates start off toggled, then they need to
+                be toggled off and back on again or delay 2 seconds apperas instant
+                on the client.
+            ]]
+            C_Timer.After(2, function()
+                local toKill = QuestieTooltips.tooltipLookup["u_" .. unitName];
+
+                if toKill then
+                    activeGUIDs[token] = unitGUID;
+
+                    local f = QuestieNameplate:getFrame(token);
+                    f:Show();
+
+                end
+            end);
+        end
+    end
+end
+
+function QuestieNameplate:NameplateDestroyed(token)
+
+    if activeGUIDs[token] then
+        activeGUIDs[token] = nil;
+        QuestieNameplate:removeFrame(token);
+    end
+    
+end
+

--- a/Questie.lua
+++ b/Questie.lua
@@ -339,6 +339,10 @@ function Questie:OnInitialize()
 	--TODO: QUEST_QUERY_COMPLETE Will get all quests the character has finished, need to be implemented!
 
 
+	-- Nameplate Quest ! for mobs to kill
+	Questie:RegisterEvent("NAME_PLATE_UNIT_ADDED", QuestieNameplate.NameplateCreated);
+	Questie:RegisterEvent("NAME_PLATE_UNIT_REMOVED", QuestieNameplate.NameplateDestroyed);
+
 	--Old stuff that has been tried, remove in cleanup
 	--Hook the questcomplete button
 	--QuestFrameCompleteQuestButton:HookScript("OnClick", CUSTOM_QUEST_COMPLETE)

--- a/QuestieDev-QuestieClassic.toc
+++ b/QuestieDev-QuestieClassic.toc
@@ -32,6 +32,7 @@ Modules\QuestieEventHandler.lua
 Modules\QuestieFramePool.lua
 Modules\QuestieMap.lua
 Modules\QuestieQuest.lua
+Modules\QuestieNameplate.lua
 
 #Main
 Questie.lua


### PR DESCRIPTION
Saw in the Questie Discord a request for placing a quest market on the mobs nameplates that are objectives for quests.  Took a shot at it and working on my Lua / addon skills.  Uses the QuestieTooltip data to add a small ! icon to the left of the nameplates for all creatures that are objectives. 

Current FramePool didn't seem to support so wrote a quick new one.  Some cleanup required.