### PR TITLE
Questie Nameplate Icons -- Objective issues

### DIFF
--- a/Modules/QuestieFramePool.lua
+++ b/Modules/QuestieFramePool.lua
@@ -243,8 +243,8 @@ function _QuestieFramePool:Questie_Tooltip(self)
 			    --if icon.data.Icon == ICON_TYPE_LOOT then -- logic needs to be improved
 			    --  table.insert(headers, icon.data.tooltip[1]);
 			    --end
-			    table.insert(contents, icon.data.tooltip[3]);
 			    table.insert(contents, icon.data.tooltip[2]);
+			    table.insert(contents, icon.data.tooltip[3]);
 			  end
 			  --table.insert(footers, icon.data.tooltip[3]);
 			  --for k,v in pairs(icon.data.tooltip) do

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -118,6 +118,8 @@ function QuestieNameplate:UpdateNameplate(self)
         
         unitName, _ = UnitName(activeGUIDs[k]);
 
+        if unitName == nil then return end
+
         local toKill = QuestieTooltips.tooltipLookup["u_" .. unitName];
 
         if toKill then

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -68,6 +68,8 @@ function QuestieNameplate:NameplateCreated(token)
     local unitGUID = UnitGUID(token);
     local unitName, _ = UnitName(token);
 
+    if not unitGUID or not unitName then return end
+
     -- we only need to use put this over creatures.
     -- to avoid running this code over Pet, Player, etc.
     local unitType = strsplit("-", unitGUID);

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -51,6 +51,7 @@ end
 function QuestieNameplate:removeFrame(guid)
     if npFrames[guid] then
         table.insert(npUnusedFrames, npFrames[guid])
+        npFrames[guid].Icon:SetTexture(nil); -- fix for overlapping icons
         npFrames[guid]:Hide();
         npFrames[guid] = nil;
     end

--- a/Modules/QuestieNameplate.lua
+++ b/Modules/QuestieNameplate.lua
@@ -8,8 +8,6 @@ local npFramesCount = 0;
 QuestieNameplate.TimerSet = 2;
 
 
-local counter = 0;
-
 -- Initializer
 function QuestieNameplate:Initialize()
     QuestieNameplate.GlobalFrame = CreateFrame("Frame");

--- a/Modules/QuestieQuest.lua
+++ b/Modules/QuestieQuest.lua
@@ -461,9 +461,9 @@ function QuestieQuest:PopulateObjectiveNotes(Quest) -- this should be renamed to
                           function data:getTooltip()
                               if(self) then
                                   local objectiveType, objectiveDesc, numItems, numNeeded, isCompleted = _QuestieQuest:GetLeaderBoardDetails(self.ObjectiveIndex, self.Id);
-                                  objectiveLine = "|cFF22FF22   " .. tostring(objectiveDesc) .. " " .. tostring(numItems) .. "/" .. tostring(numNeeded)
+                                  objectiveLine = "|cFF22FF22   "..tostring(numItems) .. "/" .. tostring(numNeeded) .. " " .. tostring(objectiveDesc)
                                   questLine = QuestieTooltips:PrintDifficultyColor(self.QuestData.Level, "[" .. self.QuestData.Level .. "] " .. self.QuestData.Name)
-                                  return {self.NPCName, objectiveLine, questLine}
+                                  return {self.NPCName, questLine, objectiveLine}
                               end
                           end
 						  data.tooltip = data:getTooltip();
@@ -517,9 +517,9 @@ function QuestieQuest:PopulateObjectiveNotes(Quest) -- this should be renamed to
                           function data:getTooltip()
                               if(self) then
                                   local objectiveType, objectiveDesc, numItems, numNeeded, isCompleted = _QuestieQuest:GetLeaderBoardDetails(self.ObjectiveIndex, self.Id);
-                                  objectiveLine = "|cFF22FF22   " .. tostring(objectiveDesc) .. " " .. tostring(numItems) .. "/" .. tostring(numNeeded)
+                                  objectiveLine = "|cFF22FF22   "..tostring(numItems) .. "/" .. tostring(numNeeded) .. " " .. tostring(objectiveDesc)
                                   questLine = QuestieTooltips:PrintDifficultyColor(self.QuestData.Level, "[" .. self.QuestData.Level .. "] " .. self.QuestData.Name)
-                                  return {self.objName, objectiveLine, questLine}
+                                  return {self.objName, questLine, objectiveLine}
                               end
                           end
 						  data.tooltip = data:getTooltip();
@@ -582,9 +582,9 @@ function QuestieQuest:PopulateObjectiveNotes(Quest) -- this should be renamed to
                   function data:getTooltip()
                       if(self) then
                           local objectiveType, objectiveDesc, numItems, numNeeded, isCompleted = _QuestieQuest:GetLeaderBoardDetails(self.ObjectiveIndex, self.Id);
-                          objectiveLine = "|cFF22FF22   " .. tostring(objectiveDesc) .. " " .. tostring(numItems) .. "/" .. tostring(numNeeded)
+                          objectiveLine = "|cFF22FF22   "..tostring(numItems) .. "/" .. tostring(numNeeded) .. " " .. tostring(objectiveDesc)
                           questLine = QuestieTooltips:PrintDifficultyColor(self.QuestData.Level, "[" .. self.QuestData.Level .. "] " .. self.QuestData.Name)
-                          return {self.NPCName, objectiveLine, questLine}
+                          return {self.NPCName, questLine, objectiveLine}
                       end
                   end
                   data.tooltip = data:getTooltip();

--- a/Modules/QuestieTooltips.lua
+++ b/Modules/QuestieTooltips.lua
@@ -76,7 +76,7 @@ function QuestieTooltips:GetTooltip(key)
 	end
 	if(type(QuestieTooltips.tooltipLookup[key][2]) == "function") then
 		local tooltip = QuestieTooltips.tooltipLookup[key][2](QuestieTooltips.tooltipLookup[key][3])
-		return {tooltip[2], "|cFFFFFFFFNeeded for: |r" .. tooltip[3]}
+		return {tooltip[2], tooltip[3]}
 	else
     	return QuestieTooltips.tooltipLookup[key][2];
 	end

--- a/Questie.lua
+++ b/Questie.lua
@@ -343,6 +343,7 @@ function Questie:OnInitialize()
 	Questie:RegisterEvent("NAME_PLATE_UNIT_ADDED", QuestieNameplate.NameplateCreated);
 	Questie:RegisterEvent("NAME_PLATE_UNIT_REMOVED", QuestieNameplate.NameplateDestroyed);
 
+
 	--Old stuff that has been tried, remove in cleanup
 	--Hook the questcomplete button
 	--QuestFrameCompleteQuestButton:HookScript("OnClick", CUSTOM_QUEST_COMPLETE)
@@ -393,6 +394,7 @@ function Questie:OnInitialize()
     Questie:debug(DEBUG_DEVELOP, "Setting clustering value to:", Questie.db.global.clusterLevel)
     QUESTIE_NOTES_CLUSTERMUL_HACK = Questie.db.global.clusterLevel;
 
+	QuestieNameplate:Initialize();
 
 end
 


### PR DESCRIPTION
Fixed 2 issues with nameplate icons.

1.) Icons will now automatically remove from quest mobs once the quest objectives are complete (There is a few second delay on this based on, I believe, the quest API latency issues)

2.) On a multi-mob quest, when you complete the objective for a single mob, other mobs on the same quest will still show their icons. 

** Note: The weird changes to other files is from updating my fork and it seemed to cause issues but they should be the same changes that are currently in the QuestieClassic branch from Logon. 