### PR TITLE
Fade over player minimap

### DIFF
--- a/Modules/QuestieMap.lua
+++ b/Modules/QuestieMap.lua
@@ -166,11 +166,15 @@ function QuestieMap:DrawWorldIcon(data, AreaID, x, y, showFlag)
                     local playerX, playerY, playerInstanceID = HBD:GetPlayerZonePosition()
                     if(playerX and playerY) then
                         local distance = QuestieFramePool:euclid(playerX, playerY, self.x / 100, self.y / 100);
+
                         --Very small value before, hard to work with.
                         distance = distance * 10
                         local NormalizedValue = 1 / (Questie.db.global.fadeLevel or 1.5);
+
                         if(distance > 0.6) then
                             self.texture:SetVertexColor(1, 1, 1, (1 - NormalizedValue * distance) + 0.5)
+                        elseif (distance < 0.1) and Questie.db.global.fadeOverPlayer then
+                            self.texture:SetVertexColor(1, 1, 1, .5)
                         else
                             self.texture:SetVertexColor(1, 1, 1, 1)
                         end
@@ -183,7 +187,7 @@ function QuestieMap:DrawWorldIcon(data, AreaID, x, y, showFlag)
             iconMinimap:SetScript("OnUpdate", function(frame)
                 --Only run if these two are true!
                 if(frame.fadeLogic and frame.miniMapIcon) then
-                    frame:fadeLogic()
+                   frame:fadeLogic()
                 end
             end)
         end

--- a/Questie.lua
+++ b/Questie.lua
@@ -249,7 +249,7 @@ local options = {
                 },
 				fadeLevel = {
 				  type = "range",
-				  order = 18,
+				  order = 19,
 				  name = "Fade objective distance",
 				  desc = "How much objective icons should fade depending on distance.",
 				  width = "double",
@@ -261,14 +261,25 @@ local options = {
 						SetGlobalOptionLocal(info, value)
 						end,
 				},
+				fadeOverPlayer = {
+					type = "toggle",
+					order = 20,
+					name = "Fade Icons over Player",
+					desc = "Fades icons on the minimap when your player walks near them.",
+					width = "full",
+					get = GetGlobalOptionLocal,
+					set = function (info, value)
+						  SetGlobalOptionLocal(info, value)
+						  end,
+				},
 				arrow_options = {
 					type = "header",
-					order = 19,
+					order = 21,
 					name = "Arrow Options",
 				},
 				test = {
 					type = "execute",
-					order = 19,
+					order = 22,
 					name = "Test Message",
 					desc = "Click this",
 					func = function() Questie:Print("Why did you click this?") end,
@@ -486,6 +497,7 @@ local defaults = {
     availableMiniMapScale = 0.75,
     objectiveMiniMapScale = 0.75,
 	fadeLevel = 1.5,
+	fadeOverPlayer = true,
 	debugEnabled = false,
 	debugLevel = 4,
     nameplateX = -17,


### PR DESCRIPTION
Updated logic to be able to fade the icons over the player on the minimap too to avoid hiding in-game nodes (such as if an herb or ore node is under an objective icon).    This can be enabled / disabled from the options. 

![image](https://user-images.githubusercontent.com/17501944/58802928-552fb500-85dc-11e9-9eda-2ce7f3aeea00.png)
