### PR TITLE
Fix #641

### DIFF
--- a/Database/corrections.lua
+++ b/Database/corrections.lua
@@ -17,7 +17,8 @@ questExclusiveGroupFixes = {
     [1943] = {1944}, -- mage robe breadcrumb
     [526] = {322,324}, -- not 100% sure on this one but it seems lightforge ingots is optional, block it after completing subsequent steps (#587)
     [3765] = {1275}, -- corruption abroad breadcrumb
-    [164] = {95} -- deliveries to sven is a breadcrumb
+    [164] = {95}, -- deliveries to sven is a breadcrumb
+    [311] = {403} -- completing the unguarded barrel quest prevents to do the optional guarded barrel prequest
 }
 
 questItemBlacklist = {


### PR DESCRIPTION
The [Guarded Thunderbrew Barrel](https://classic.wowhead.com/quest=403/guarded-thunderbrew-barrel) is an optional quest which can't be done if the [Return to Marleth](https://classic.wowhead.com/quest=311/return-to-marleth) quest has been done before.

This PR adds the quest IDs to the questExclusiveGroupFixes.