### PR TITLE
Fix regression on non english client

### DIFF
--- a/Modules/QuestieQuest.lua
+++ b/Modules/QuestieQuest.lua
@@ -793,7 +793,7 @@ function QuestieQuest:GetAllQuestObjectives(Quest)
                     end
                 end
                 -- 2nd pass (fix for missing language data)
-                if Quest.Objectives[i].Id == nil then
+                if Quest.Objectives[i].Id == nil and GetLocale() ~= "enUS" and GetLocale() ~= "enGB" then
                     for k,v in pairs(Quest.ObjectiveData) do
                         if objectiveType == v.Type then
                             -- When nothing is found (other languages) fill it.


### PR DESCRIPTION
It seems that there has been a regression, on English clients (see bug #651). 

We restrict the 2nd pass only for other languages. (PR # 644).