### PR TITLE
Disable texel snapping to reduce icon wobbling on the minimap

### DIFF
--- a/Modules/QuestieFramePool.lua
+++ b/Modules/QuestieFramePool.lua
@@ -122,6 +122,8 @@ function _QuestieFramePool:QuestieCreateFrame()
     t:SetWidth(16)
     t:SetHeight(16)
     t:SetAllPoints(f)
+    t:SetTexelSnappingBias(0)
+    t:SetSnapToPixelGrid(false)
 
     local glowt = f.glow:CreateTexture(nil, "TOOLTIP")
     glowt:SetWidth(18)


### PR DESCRIPTION
Textures by default will snap to a pixel grid instead of using sub-pixel rendering, which does produce a sort of wobbling icon effect when textures are being animated/moved over the minimap.

Disable the snapping to get a smoother icon movement on the minimap.