### PR TITLE
Fix off-by-one issue level filter.

### DIFF
--- a/Modules/QuestieQuest.lua
+++ b/Modules/QuestieQuest.lua
@@ -1224,7 +1224,7 @@ function QuestieQuest:CalculateAvailableQuests()
 
         if((not Questie.db.char.complete[QuestID]) and (not QuestieCorrections.hiddenQuests[QuestID]) and (not qCurrentQuestlog[QuestID])) then --Should be not qCurrentQuestlog[QuestID]
             local Quest = QuestieDB:GetQuest(QuestID);
-            if (Quest.Level > MinLevel or Questie.db.char.lowlevel) and Quest.Level < MaxLevel and Quest.MinLevel <= PlayerLevel then
+            if (Quest.Level >= MinLevel or Questie.db.char.lowlevel) and Quest.Level <= MaxLevel and Quest.MinLevel <= PlayerLevel then
                 if _QuestieQuest:IsDoable(Quest) then
                     qAvailableQuests[QuestID] = QuestID
                 end


### PR DESCRIPTION
When the player level is 10 and the minimum level filter is 1, quests with level 9 should be visible. Similarly, when the maximum level filter is 1, quests with level 11 should be visible.

I've tested this with [a level 43 quest](https://classic.wowhead.com/quest=2342/reclaimed-treasures), a level 33 character and the maximum level filter ("how many levels above your character to show") set to 10. Before the change, the quest doesn't show up. After the change, it does.