### PR TITLE
Add Burning Blade members to drop gems to fix #751

### DIFF
--- a/Database/corrections.lua
+++ b/Database/corrections.lua
@@ -94,6 +94,7 @@ QuestieCorrections.itemFixes = {
     [8585] = {"Tapped Dowsing Widget",{992},{},{144052}},
     [11149] = {"Samophlange Manual",{3924},{},{}},
     [11018] = {"Un\'Goro Soil",{4496,3761,3764},{},{157936}},
+    [6435] = {"Infused Burning Gem",{1435},{4663,4664,4665,4666,4667,4668,4705,13019},{}},
 	
     -- quest related herbs
     [2449] = {"Earthroot",{6123,6128},{},{1619,3726}},


### PR DESCRIPTION
The "Buring Blade X" mobs need to be hurt before using an quest item which makes the mobs drop the items required for the quest of #751 
This PR adds those mobs to drop the item which is kind of a work around, but imo better than no objectives shown.