### PR TITLE
Fixed quest log not closing on escape press.

### DIFF
--- a/Modules/QuestieTracker.lua
+++ b/Modules/QuestieTracker.lua
@@ -200,7 +200,7 @@ local function _ShowQuestLog(Quest)
             QuestLogExFrameMaximizeButton:GetScript("OnClick")(QuestLogExFrameMaximizeButton)
         end
     else
-       ToggleQuestLog();
+        ToggleQuestLog();
     end    
     SelectQuestLogEntry(GetQuestLogIndexByID(Quest.Id))
     QuestLog_UpdateQuestDetails()

--- a/Modules/QuestieTracker.lua
+++ b/Modules/QuestieTracker.lua
@@ -200,7 +200,7 @@ local function _ShowQuestLog(Quest)
             QuestLogExFrameMaximizeButton:GetScript("OnClick")(QuestLogExFrameMaximizeButton)
         end
     else
-        QuestLogFrame:Show()
+       ToggleQuestLog();
     end    
     SelectQuestLogEntry(GetQuestLogIndexByID(Quest.Id))
     QuestLog_UpdateQuestDetails()


### PR DESCRIPTION
### Issue #1033
Currently, when a user opens the quest log via shift clicking the QuestieTracker, they are unable to close it using the escape button after. This pull request address that. 