### PR TITLE
Change position of Map button when continent dropdown is hidden

### DIFF
--- a/Questie.lua
+++ b/Questie.lua
@@ -238,6 +238,15 @@ function Questie:OnInitialize()
     else
         Questie_Toggle:Hide();
     end
+
+    -- Change position of Map button when continent dropdown is hidden
+    C_Timer.After(1, function()
+        if not WorldMapContinentDropDown:IsShown() then
+            Questie_Toggle:ClearAllPoints();
+            Questie_Toggle:SetPoint('RIGHT', WorldMapFrameCloseButton, 'LEFT', 0, 0);
+        end
+    end);
+
     if Questie.db.global.dbmHUDEnable then
         QuestieDBMIntegration:EnableHUD()
     end


### PR DESCRIPTION
Small change I've had active locally for a while:

If `WorldMapContinentDropDown` is hidden, move the `Questie_Toggle` button to be left of the `WorldMapFrameCloseButton` instead.

There are addons that hide parts of the World Map UI, most notably the `WorldMapFrame.BorderFrame` and/or buttons/dropdowns on it, making the "Hide Questie"/"Show Questie" button appear to float in a weird position. This solves the issue, at least for addons that do still show the close button.