### PR TITLE
Fixes tracking of repeatable quests

### DIFF
--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -365,7 +365,7 @@ end
 function QuestieQuest:CompleteQuest(quest)
     local questId = quest.Id
     QuestiePlayer.currentQuestlog[questId] = nil;
-    Questie.db.char.complete[questId] = quest and not quest.Repeatable
+    Questie.db.char.complete[questId] = not quest.Repeatable
     QuestieHash:RemoveQuestHash(questId)
 
     --This should probably be done first, because DrawAllAvailableQuests looks at QuestieMap.questIdFrames[QuestId] to add available

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -362,9 +362,10 @@ function QuestieQuest:AcceptQuest(questId)
 
 end
 
-function QuestieQuest:CompleteQuest(questId)
+function QuestieQuest:CompleteQuest(quest)
+    local questId = quest.Id
     QuestiePlayer.currentQuestlog[questId] = nil;
-    Questie.db.char.complete[questId] = true --can we use some other relevant info here?
+    Questie.db.char.complete[questId] = quest and not quest.Repeatable
     QuestieHash:RemoveQuestHash(questId)
 
     --This should probably be done first, because DrawAllAvailableQuests looks at QuestieMap.questIdFrames[QuestId] to add available

--- a/Modules/Quest/QuestieQuest.lua
+++ b/Modules/Quest/QuestieQuest.lua
@@ -365,6 +365,7 @@ end
 function QuestieQuest:CompleteQuest(quest)
     local questId = quest.Id
     QuestiePlayer.currentQuestlog[questId] = nil;
+    -- Only quests that aren't repeatable should be marked complete, otherwise objectives for repeatable quests won't track correctly - #1433
     Questie.db.char.complete[questId] = not quest.Repeatable
     QuestieHash:RemoveQuestHash(questId)
 

--- a/Modules/QuestieEventHandler.lua
+++ b/Modules/QuestieEventHandler.lua
@@ -131,7 +131,7 @@ function QuestieEventHandler:CompleteQuest(questId, count)
         return
     end
     if(IsQuestFlaggedCompleted(questId) or quest.Repeatable or count > 50) then
-        QuestieQuest:CompleteQuest(questId)
+        QuestieQuest:CompleteQuest(quest)
         QuestieJourney:CompleteQuest(questId)
     else
         Questie:Debug(DEBUG_INFO, "[QuestieEventHandler]", questId, ":Quest not complete starting timer! IsQuestFlaggedCompleted", IsQuestFlaggedCompleted(questId), "Repeatable:", quest.Repeatable, "Count:", count);


### PR DESCRIPTION
Fixes #1433

Either of these changes in isolation would fix the issue.

Either repeatable quests should be considered `complete` or we should be laxer about updating them. 

I'm not entirely sure of the structure of the `Questie.db` object or what the `Questie.db.char.complete` map is meant to track, so this seems kind of hack-ish to me. Open to any feedback here.