### PR TITLE
Thick Yeti Fur does not drop from Ice Thistle Matriarch/Patriarch

### DIFF
--- a/Database/Corrections/QuestieItemFixes.lua
+++ b/Database/Corrections/QuestieItemFixes.lua
@@ -658,6 +658,9 @@ function QuestieItemFixes:Load()
             [QuestieDB.itemKeys.npcDrops] = {},
             [QuestieDB.itemKeys.objectDrops] = {400003},
         },
+        [12366] = {
+            [QuestieDB.itemKeys.npcDrops] = {7457,7458},
+        },
 
         -- quest related herbs
         [2449] = {


### PR DESCRIPTION
As the title says, `Thick Yeti Fur` does **not** drop from `Ice Thistle Matriarch` or `Ice Thistle Patriarch`, so remove these two from the list.