### PR TITLE
Fix error thrown when auto accepting quests not in the database

### DIFF
--- a/Modules/Auto/QuestieAuto.lua
+++ b/Modules/Auto/QuestieAuto.lua
@@ -187,8 +187,7 @@ function QuestieAuto:QUEST_DETAIL(event, ...)
                 quest = QuestieDB:GetQuest(questId)
                 if quest == nil then
                     Questie:Debug(DEBUG_DEVELOP, "retry failed. Quest", questId, "might not be in the DB!")
-                end
-                if (not quest:IsTrivial()) or Questie.db.char.acceptTrivial then
+                elseif (not quest:IsTrivial()) or Questie.db.char.acceptTrivial then
                     Questie:Debug(DEBUG_INFO, "Questie Auto-Acceping quest")
                     AcceptQuest()
                 end


### PR DESCRIPTION
As discussed in the questie discord i changed the if statement to be an elseif.