### PR TITLE
Fix for Twilight Tablet drops

### DIFF
--- a/Database/Corrections/QuestieItemFixes.lua
+++ b/Database/Corrections/QuestieItemFixes.lua
@@ -985,6 +985,10 @@ function QuestieItemFixes:Load()
         [20023] = {
             [QuestieDB.itemKeys.npcDrops] = {8766},
         },
+        [20378] = {
+            [QuestieDB.itemKeys.npcDrops] = {14435, 14347},
+            [QuestieDB.itemKeys.objectDrops] = {180436,180501},
+        },
         [21557] = {
             [QuestieDB.itemKeys.name] = "Small Red Rocket",
             [QuestieDB.itemKeys.relatedQuests] = {8867,},


### PR DESCRIPTION
@Rillant reported this in Discord, and another person in-game reported this to me earlier in the week that they were showing up on the elementals. This should fix the issue.