### PR TITLE
Fixes for 2 Quests - Broken Alliances & Tremors of the Earth

### DIFF
--- a/Database/Corrections/QuestieItemFixes.lua
+++ b/Database/Corrections/QuestieItemFixes.lua
@@ -258,6 +258,24 @@ function QuestieItemFixes:Load()
         [4806] = {
             [QuestieDB.itemKeys.npcDrops] = {2956,2957,3068},
         },
+        [4843] = {
+            [QuestieDB.itemKeys.name] = "Amethyst Runestone",
+            [QuestieDB.itemKeys.relatedQuests] = {793,717},
+            [QuestieDB.itemKeys.npcDrops] = {},
+            [QuestieDB.itemKeys.objectDrops] = {2858},
+        },
+        [4844] = {
+            [QuestieDB.itemKeys.name] = "Opal Runestone",
+            [QuestieDB.itemKeys.relatedQuests] = {793,717},
+            [QuestieDB.itemKeys.npcDrops] = {},
+            [QuestieDB.itemKeys.objectDrops] = {2848},
+	    },
+        [4845] = {
+            [QuestieDB.itemKeys.name] = "Diamond Runestone",
+            [QuestieDB.itemKeys.relatedQuests] = {793,717},
+            [QuestieDB.itemKeys.npcDrops] = {},
+            [QuestieDB.itemKeys.objectDrops] = {2842},
+        },
         [4904] = {
             [QuestieDB.itemKeys.name] = "Venomtail Antidote",
             [QuestieDB.itemKeys.relatedQuests] = {812},


### PR DESCRIPTION
These quests require stones from these pillars to call the dragons that you need to kill. Adding the stones / pillars in.

	https://classic.wowhead.com/quest=793/broken-alliances
	https://classic.wowhead.com/quest=717/tremors-of-the-earth

	Pillar of Amethyst: 81,63
	https://classic.wowhead.com/object=2858/pillar-of-amethyst
	https://classic.wowhead.com/item=4843/amethyst-runestone

	Pillar of Opal: 72,66
	https://classic.wowhead.com/object=2848/pillar-of-opal
	https://classic.wowhead.com/item=4844/opal-runestone

	Pillar of Diamond: 83,33
	https://classic.wowhead.com/object=2842/pillar-of-diamond
	https://classic.wowhead.com/item=4845/diamond-runestone