### PR TITLE
Fixes for Marg Speaks Quest

### DIFF
--- a/Database/Corrections/QuestieItemFixes.lua
+++ b/Database/Corrections/QuestieItemFixes.lua
@@ -377,7 +377,6 @@ function QuestieItemFixes:Load()
             [QuestieDB.itemKeys.objectDrops] = {20806},
         },
         [5942] = {
-            [QuestieDB.itemKeys.name] = "Jeweled Pendant",
             [QuestieDB.itemKeys.relatedQuests] = {1261},
             [QuestieDB.itemKeys.npcDrops] = {4405,4401,4404,4402,4403,14236},
             [QuestieDB.itemKeys.objectDrops] = {},

--- a/Database/Corrections/QuestieItemFixes.lua
+++ b/Database/Corrections/QuestieItemFixes.lua
@@ -376,6 +376,12 @@ function QuestieItemFixes:Load()
             [QuestieDB.itemKeys.npcDrops] = {},
             [QuestieDB.itemKeys.objectDrops] = {20806},
         },
+        [5942] = {
+            [QuestieDB.itemKeys.name] = "Jeweled Pendant",
+            [QuestieDB.itemKeys.relatedQuests] = {1261},
+            [QuestieDB.itemKeys.npcDrops] = {4405,4401,4404,4402,4403,14236},
+            [QuestieDB.itemKeys.objectDrops] = {},
+        },
         [6016] = {
             [QuestieDB.itemKeys.name] = "Wolf Heart Sample",
             [QuestieDB.itemKeys.relatedQuests] = {1429},


### PR DESCRIPTION
# [40] Marg Speaks 
	- Not showing right spots for all the crabs.

	https://classic.wowhead.com/quest=1261/marg-speaks
	https://classic.wowhead.com/item=5942/jeweled-pendant

	https://classic.wowhead.com/npc=4405/muckshell-razorclaw
	https://classic.wowhead.com/npc=4401/muckshell-clacker
	https://classic.wowhead.com/npc=4404/muckshell-scrabbler
	https://classic.wowhead.com/npc=4402/muckshell-snapclaw
	https://classic.wowhead.com/npc=4403/muckshell-pincer
	https://classic.wowhead.com/npc=14236/lord-angler

DB:
[5942]={"Jeweled Pendant",{1261,1262},{4401,4402,4403,4404,4405,14236,4401,4402,4403,4404,4405,14236},{}},