### PR TITLE
[quest] Fixes for [30] Test of Endurance

### DIFF
--- a/Database/Corrections/QuestieNPCFixes.lua
+++ b/Database/Corrections/QuestieNPCFixes.lua
@@ -183,6 +183,9 @@ function QuestieNPCFixes:Load()
         [4479] = {
             [QuestieDB.npcKeys.spawns] = {[45]={{56.55,38.7},{54.8,38.2},},},
         },
+        [4490] = {
+            [QuestieDB.npcKeys.spawns] = {[400]={{26,55.4},{26,55.6},{26.6,55.8},{26.8,55.4},},},
+        },
         [4499] = {
             [QuestieDB.npcKeys.spawns] = {[400]={{17.1,38.1},{10.6,23.1},},},
         },


### PR DESCRIPTION
Grenka spawns after you loot some chests, but we didn't have her location. Adding it, without it, there's no indicator on the map.

* Test of Endurance - Quest - World of Warcraft || https://classic.wowhead.com/quest=1150/test-of-endurance

* Grenka Bloodscreech - NPC - World of Warcraft || https://classic.wowhead.com/npc=4490/grenka-bloodscreech

* Grenka's Claw - Item - World of Warcraft || https://classic.wowhead.com/item=5843/grenkas-claw