### PR TITLE
Fix #1870

### DIFF
--- a/Database/Corrections/QuestieQuestFixes.lua
+++ b/Database/Corrections/QuestieQuestFixes.lua
@@ -1981,7 +1981,7 @@ function QuestieQuestFixes:Load()
             [questKeys.requiredRaces] = 178,
         },
         [8314] = {
-            [questKeys.specialFlags] = nil, -- #1870
+            [questKeys.specialFlags] = 0, -- #1870
         },
         [8331]  ={
             [questKeys.exclusiveTo] = {},


### PR DESCRIPTION
DB compression doesn't handle nil. Already thought to have been fixed. Not needed in changelog again.