### PR TITLE
[quest] Fixes for Saving Yenniku

### DIFF
--- a/Database/Corrections/QuestieItemFixes.lua
+++ b/Database/Corrections/QuestieItemFixes.lua
@@ -197,6 +197,9 @@ function QuestieItemFixes:Load()
         [3864] = {
             [itemKeys.npcDrops] = {},
         },
+        [3913] = {
+            [QuestieDB.itemKeys.npcDrops] = {2530},
+        },
         [4016] = {
             [itemKeys.npcDrops] = {1488,1489,1490,1491,2530,2534,2535,2536,2537},
         },


### PR DESCRIPTION
[[46] Saving Yenniku (592)] -- missing objectives on map, add soul gem / Filled Soul Gem

    Saving Yenniku - Quest - World of Warcraft || https://classic.wowhead.com/quest=592/saving-yenniku

    Filled Soul Gem - Item - World of Warcraft || https://classic.wowhead.com/item=3913/filled-soul-gem

    Yenniku - NPC - World of Warcraft || https://classic.wowhead.com/npc=2530/yenniku

    [592] = {"Saving Yenniku",{{2519,},nil,nil,},{{2497,},nil,},30,46,178,nil,{"Bring the Filled Soul Gem to Nimboya.",},nil,{nil,nil,{{3913,nil},},nil,},3912,nil,{591,},{593,},nil,nil,33,nil,nil,nil,nil,nil,nil,nil,nil,},

    [2530] = {'Yenniku',1902,1902,41,41,0,{[33]={{39.02,58.35},},},nil,33,{593,},{593,},28,nil,"Darkspear Hostage",2


https://github.com/AeroScripts/QuestieDev/pull/2107