### PR TITLE
Get version string without parsing title

### DIFF
--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -980,13 +980,6 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipmap, keyToRootIndex, 
     return handle
 end
 
-function QuestieDBCompiler:GetVersionString() -- todo: better place
-    local _,ver = GetAddOnInfo("Questie")
-    if not ver then
-        _,ver = GetAddOnInfo("QuestieDev-master")
-    end
-    -- todo: better regex for this
-    ver = string.sub(ver, 32)
-    ver = string.sub(ver, 0, string.find(ver, "|")-1)
-    return ver
+function QuestieDBCompiler:GetVersionString()
+    return GetAddOnMetadata("Questie", "Version")
 end

--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -981,7 +981,3 @@ function QuestieDBCompiler:GetDBHandle(data, pointers, skipmap, keyToRootIndex, 
 
     return handle
 end
-
-function QuestieDBCompiler:GetVersionString()
-    return GetAddOnMetadata("Questie", "Version")
-end

--- a/Database/compiler.lua
+++ b/Database/compiler.lua
@@ -8,6 +8,8 @@ local QuestieStream = QuestieLoader:ImportModule("QuestieStreamLib"):GetStream("
 local QuestieDB = QuestieLoader:ImportModule("QuestieDB")
 ---@type QuestieSerializer
 local serial = QuestieLoader:ImportModule("QuestieSerializer")
+---@type QuestieLib
+local QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 
 serial.enableObjectLimit = false
 
@@ -631,7 +633,7 @@ function QuestieDBCompiler:Compile(finalize)
                 QuestieDBCompiler:CompileItems(function(bin, ptrs)
                     QuestieConfig.itemBin = bin 
                     QuestieConfig.itemPtrs = ptrs
-                    QuestieConfig.dbCompiledOnVersion = QuestieDBCompiler:GetVersionString()
+                    QuestieConfig.dbCompiledOnVersion = QuestieLib:GetAddonVersionString()
                     QuestieConfig.dbCompiledLang = (Questie.db.global.questieLocaleDiff and Questie.db.global.questieLocale or GetLocale())
                     QuestieConfig.dbIsCompiled = true
                     --print("\124cFF4DDBFF [4/4] Finished updating items")

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -344,12 +344,9 @@ function QuestieLib:GetAddonVersionInfo()
     local major, minor, patch = string.match(version, "(%d+)%p(%d+)%p(%d+)")
 
     if (not cachedTitle) then
-        --[[ not really sure why QuestiDev-master is checked
-        local name, title, _, _, reason = GetAddOnInfo("QuestieDev-master")
-        if (reason == "MISSING") then _, title = GetAddOnInfo("Questie") end
+        local _, title, _, _, reason = GetAddOnInfo("QuestieDev-master")
+        if (reason == "MISSING") then _, title = GetAddOnInfo(name) end
         cachedTitle = title
-        ]]--
-        _, cachedTitle = GetAddOnInfo(name)
     end
 
     local buildType = nil

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -336,18 +336,18 @@ function QuestieLib:Remap(value, low1, high1, low2, high2)
 end
 
 local cachedTitle = nil
+local cachedVersion = nil
 -- Move to Questie.lua after QuestieOptions move.
 function QuestieLib:GetAddonVersionInfo()
-    local name = "Questie"
-    local version = GetAddOnMetadata(name, "Version")
-    -- %d = digit, %p = punctuation character, %x = hexadecimal digits.
-    local major, minor, patch = string.match(version, "(%d+)%p(%d+)%p(%d+)")
-
-    if (not cachedTitle) then
-        local _, title, _, _, reason = GetAddOnInfo("QuestieDev-master")
-        if (reason == "MISSING") then _, title = GetAddOnInfo(name) end
+    if (not cachedTitle or not cachedVersion) then
+        local name, title, _, _, reason = GetAddOnInfo("QuestieDev-master")
+        if (reason == "MISSING") then name, title = GetAddOnInfo("Questie") end
         cachedTitle = title
+        cachedVersion = GetAddOnMetadata(name, "Version")
     end
+
+    -- %d = digit, %p = punctuation character, %x = hexadecimal digits.
+    local major, minor, patch = string.match(cachedVersion, "(%d+)%p(%d+)%p(%d+)")
 
     local buildType = nil
 

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -338,14 +338,19 @@ end
 local cachedTitle = nil
 -- Move to Questie.lua after QuestieOptions move.
 function QuestieLib:GetAddonVersionInfo()
+    local name = "Questie"
+    local version = GetAddOnMetadata(name, "Version")
+    -- %d = digit, %p = punctuation character, %x = hexadecimal digits.
+    local major, minor, patch = string.match(version, "(%d+)%p(%d+)%p(%d+)")
+
     if (not cachedTitle) then
+        --[[ not really sure why QuestiDev-master is checked
         local name, title, _, _, reason = GetAddOnInfo("QuestieDev-master")
         if (reason == "MISSING") then _, title = GetAddOnInfo("Questie") end
         cachedTitle = title
+        ]]--
+        _, cachedTitle = GetAddOnInfo(name)
     end
-    -- %d = digit, %p = punctuation character, %x = hexadecimal digits.
-    local major, minor, patch = string.match(cachedTitle,
-                                                     "(%d+)%p(%d+)%p(%d+)")
 
     local buildType = nil
 

--- a/Modules/Libs/QuestieLib.lua
+++ b/Modules/Libs/QuestieLib.lua
@@ -339,7 +339,7 @@ local cachedTitle = nil
 local cachedVersion = nil
 -- Move to Questie.lua after QuestieOptions move.
 function QuestieLib:GetAddonVersionInfo()
-    if (not cachedTitle or not cachedVersion) then
+    if (not cachedTitle) or (not cachedVersion) then
         local name, title, _, _, reason = GetAddOnInfo("QuestieDev-master")
         if (reason == "MISSING") then name, title = GetAddOnInfo("Questie") end
         cachedTitle = title

--- a/Modules/QuestieEventHandler.lua
+++ b/Modules/QuestieEventHandler.lua
@@ -144,7 +144,7 @@ _PLAYER_LOGIN = function()
         QuestieTracker:Initialize()
     end
 
-    if QuestieDBCompiler:GetVersionString() ~= QuestieConfig.dbCompiledOnVersion or (Questie.db.global.questieLocaleDiff and Questie.db.global.questieLocale or GetLocale()) ~= QuestieConfig.dbCompiledLang then
+    if QuestieLib:GetAddonVersionString() ~= QuestieConfig.dbCompiledOnVersion or (Questie.db.global.questieLocaleDiff and Questie.db.global.questieLocale or GetLocale()) ~= QuestieConfig.dbCompiledLang then
         QuestieConfig.dbIsCompiled = nil -- we need to recompile
     end
 


### PR DESCRIPTION
I think it's better to grab the Version field defined in toc, rather than parsing the title.