### PR TITLE
[quest] Updates for Tremors of the Earth and Broken Alliances

### DIFF
--- a/Database/Corrections/QuestieQuestFixes.lua
+++ b/Database/Corrections/QuestieQuestFixes.lua
@@ -283,6 +283,9 @@ function QuestieQuestFixes:Load()
             [QuestieDB.questKeys.preQuestGroup] = {712,714,},
             [QuestieDB.questKeys.requiredSkill] = {},
         },
+        [717] = {
+            [questKeys.requiredSourceItems] = {4843,4844,4845,},
+        },
         [730] = {
             [questKeys.exclusiveTo] = {729}, -- #1587
             [questKeys.zoneOrSort] = 1657,
@@ -316,6 +319,9 @@ function QuestieQuestFixes:Load()
         },
         [781] = {
             [questKeys.startedBy] = {nil,{3076},{4851,},},
+        },
+        [793] = {
+            [questKeys.requiredSourceItems] = {4843,4844,4845,},
         },
         [819] = {
             [questKeys.startedBy] = {nil,{3238},{4926,},},


### PR DESCRIPTION
* Tremors of the Earth - Quest - World of Warcraft || https://classic.wowhead.com/quest=717/tremors-of-the-earth
* Broken Alliances - Quest - World of Warcraft || https://classic.wowhead.com/quest=793/broken-alliances

![image](https://user-images.githubusercontent.com/55365231/86520076-91000400-be06-11ea-9657-c2ab82be023d.png)
