### PR TITLE
[quest] Updated objective locations for "Dearest Natalia"

### DIFF
--- a/Database/Corrections/QuestieQuestFixes.lua
+++ b/Database/Corrections/QuestieQuestFixes.lua
@@ -1985,6 +1985,9 @@ function QuestieQuestFixes:Load()
         [8296] = { -- bad race data
             [questKeys.requiredRaces] = 178,
         },
+        [8304] = {
+            [questKeys.objectives] = {{{15171,"Frankal Questioned"},{15170,"Rutgar Questioned"},},nil,nil,nil,},
+        },
         [8314] = {
             [questKeys.specialFlags] = 0, -- #1870
         },


### PR DESCRIPTION
Setting objective to the actual NPC (for mouseover) instead of an invisible trigger.