### PR TITLE
Handle already loaded ZoneHelper

### DIFF
--- a/Libs/ZoneHelper/ZoneHelper.lua
+++ b/Libs/ZoneHelper/ZoneHelper.lua
@@ -4,6 +4,7 @@
 
 local AceEvent = LibStub:GetLibrary("AceEvent-3.0");
 local helper = LibStub:NewLibrary("ZoneHelper-1.0", 1);
+if not helper then return end
 
 local zoneIDToUiMapID = {};
 


### PR DESCRIPTION
This should help avoid errors loading when other addons have already defined this library.