### PR TITLE
[quest] Marked "Digging Through the Dirt" as repeatable

### DIFF
--- a/Database/Corrections/QuestieQuestFixes.lua
+++ b/Database/Corrections/QuestieQuestFixes.lua
@@ -95,6 +95,9 @@ function QuestieQuestFixes:Load()
         },
         [254] = {
             [questKeys.parentQuest] = 253,
+            [questKeys.specialFlags] = 1,
+            [questKeys.exclusiveTo] = {253}, --#2173
+            [questKeys.preQuestSingle] = {252},
         },
         [273] = {
             [questKeys.triggerEnd] = {"Find Huldar, Miran, and Saean",{[zoneIDs.LOCH_MODAN]={{51.16, 68.96},},},},


### PR DESCRIPTION
'preQuestSingle' to not have it shown as repeatable all the time in Duskwood. 
'exclusiveTo' because it's unavailable after completion of 253.
'specialFlags' because it's used to summon the boss. Can be done more than once (repeatable).
Partly fixes #2173