### PR TITLE
[quest] Marked "Assisting Arch Druid Runetotem" as breadcrumb quest

### DIFF
--- a/Database/Corrections/QuestieQuestFixes.lua
+++ b/Database/Corrections/QuestieQuestFixes.lua
@@ -402,6 +402,9 @@ function QuestieQuestFixes:Load()
         [930] = {
             [questKeys.preQuestSingle] = {918,919}, -- #971
         },
+        [936] = {
+            [questKeys.exclusiveTo] = {3762,3784,3761},
+        },
         [938] = {
             [questKeys.triggerEnd] = {"Lead Mist safely to Sentinel Arynia Cloudsbreak", {[zoneIDs.TELDRASSIL]={{38.33,34.39},},},},
         },
@@ -1037,8 +1040,14 @@ function QuestieQuestFixes:Load()
         [3702] = {
             [questKeys.triggerEnd] = {"Story of Thaurissan", {[zoneIDs.IRONFORGE]={{38.62,55.44},},},},
         },
+        [3762] = {
+            [questKeys.exclusiveTo] = {936,3784,3761},
+        },
         [3765] = {
             [questKeys.exclusiveTo] = {1275}, -- corruption abroad breadcrumb
+        },
+        [3784] = {
+            [questKeys.exclusiveTo] = {936,3762,3761},
         },
         [3791] = {
             [questKeys.preQuestSingle] = {3787,3788}, -- #885


### PR DESCRIPTION
Added Un'Goro Soil (3761) to the breadcrumbs since all three will be disabled when you complete it.