### PR TITLE
[quest] Marked "Denalan's Earth" as breadcrumb quest

### DIFF
--- a/Database/Corrections/QuestieQuestFixes.lua
+++ b/Database/Corrections/QuestieQuestFixes.lua
@@ -391,6 +391,9 @@ function QuestieQuestFixes:Load()
         [911] = {
             [questKeys.triggerEnd] = {"Go to the Mor'shan Rampart in the Barrens.", {[zoneIDs.THE_BARRENS]={{47.9,5.36},},},},
         },
+        [918] = {
+            [questKeys.preQuestSingle] = {},
+        },
         [924] = {
             [questKeys.requiredSourceItems] = {4986},
         },


### PR DESCRIPTION
997 "Denalan's Earth" is not required for 918. Completing 918 does NOT disable 997 "Denalan's Earth".