### PR TITLE
Remove questie from quest announce text

### DIFF
--- a/Locale/enUS/config.lua
+++ b/Locale/enUS/config.lua
@@ -71,8 +71,8 @@ QuestieLocale.locale['enUS'] = {
     ['QUEST_ANNOUNCE'] = "Quest Announce",
     ['QUEST_ANNOUNCE_DESC'] = "Announce objective completion to party members",
     ['QUEST_ANNOUNCE_ENABLED'] = "Enabled",
-    ['QUEST_ANNOUNCE_OBJECTIVE'] = "{rt1} Questie : %s for %s!",
-    ['QUEST_ANNOUNCE_QUESTITEM'] = "{rt1} Questie : Picked up %s which starts %s!",
+    ['QUEST_ANNOUNCE_OBJECTIVE'] = "{rt1} %s for %s",
+    ['QUEST_ANNOUNCE_QUESTITEM'] = "{rt1} Picked up %s which starts %s",
 
     -- Minimap tab
     ['MINIMAP_TAB'] = "Minimap",

--- a/Locale/ruRU/config.lua
+++ b/Locale/ruRU/config.lua
@@ -71,8 +71,8 @@ QuestieLocale.locale['ruRU'] = {
     ['QUEST_ANNOUNCE'] = "Сообщить о задании",
     ['QUEST_ANNOUNCE_DESC'] = "Сообщает о выполнении цели задания членам группы",
     ['QUEST_ANNOUNCE_ENABLED'] = "Включено",
-    ['QUEST_ANNOUNCE_OBJECTIVE'] = "{rt1} Questie : %s для %s!",
-    ['QUEST_ANNOUNCE_QUESTITEM'] = "{rt1} Questie : Данный предмет - %s - начинает %s!",
+    ['QUEST_ANNOUNCE_OBJECTIVE'] = "{rt1} %s для %s",
+    ['QUEST_ANNOUNCE_QUESTITEM'] = "{rt1} Данный предмет - %s - начинает %s",
 
     -- Minimap tab
     ['MINIMAP_TAB'] = "Миникарта",

--- a/Locale/zhCN/config.lua
+++ b/Locale/zhCN/config.lua
@@ -72,8 +72,8 @@ QuestieLocale.locale['zhCN'] = {
     ['QUEST_ANNOUNCE'] = "任务进度通报",
     ['QUEST_ANNOUNCE_DESC'] = "向队员通报任务进度完成情况",
     ['QUEST_ANNOUNCE_ENABLED'] = "已启用",
-    ['QUEST_ANNOUNCE_OBJECTIVE'] = "{rt1} Questie : %s 任务： %s!",
-    ['QUEST_ANNOUNCE_QUESTITEM'] = "{rt1} Questie : 拾取 %s 自动接受任务： %s!",
+    ['QUEST_ANNOUNCE_OBJECTIVE'] = "{rt1} %s 任务： %s",
+    ['QUEST_ANNOUNCE_QUESTITEM'] = "{rt1} 拾取 %s 自动接受任务： %s",
     
     -- Minimap tab
     ['MINIMAP_TAB'] = "小地图",


### PR DESCRIPTION
The quest announcing in party chat is sometimes really long, and it does not really need to say "Questie" every time.

If you don't want to merge this PR, I suggest that you correct the grammar - there is not supposed to be a space before the colon. That's a French grammar thing, not English.

Thanks 😊